### PR TITLE
fix nav-bar failing if browser's width less than 1200px

### DIFF
--- a/sense.css
+++ b/sense.css
@@ -1,5 +1,6 @@
 body {
-    margin: 0
+    margin: 0px;
+    min-width: 1200px;
 }
 
 .pull-right-btn {
@@ -53,6 +54,7 @@ body {
     bottom: 0;
     left: 484px;
     right: 0;
+    min-width: 700px;
 }
 
 #autocomplete {


### PR DESCRIPTION
Very simple fix. Sometimes I work from my laptop with not very big screen resolution, not Retina yet :) and I see something like you can see on the screenshot.

![screen shot 2013-08-17 at 18 04 54](https://f.cloud.github.com/assets/169803/981372/2cd033d4-075f-11e3-97bc-9e9dbb169ea4.png)
