### PR TITLE
Auto-detect server if running as es plugin

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -209,6 +209,9 @@ function init() {
 
    var es_server = $("#es_server");
 
+   if (document.location.protocol != "chrome-extension:" && document.location.host != "") {
+      es_server.attr('value', document.location.host);
+   }
    es_server.blur(function () {
       sense.mappings.notifyServerChange(es_server.val());
    });


### PR DESCRIPTION
This makes it easier to run sense as an elasticsearch plugin by trying to auto-detect the es server based on the document location.

See issue #21 for more info.
