### PR TITLE
Added the ability to paste more than one curl command at a time.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "quotmark": false,
+  "indent": 3
+}

--- a/index.html
+++ b/index.html
@@ -145,6 +145,7 @@
 <script src="kb/warmers.js" type="text/javascript" charset="utf-8"></script>
 <script src="kb/mappings.js" type="text/javascript" charset="utf-8"></script>
 <script src="kb/misc.js" type="text/javascript" charset="utf-8"></script>
+<script src="src/minimist.js" type="text/javascript" charset="utf-8"></script>
 <script src="src/curl.js" type="text/javascript" charset="utf-8"></script>
 <script src="src/base.js" type="text/javascript" charset="utf-8"></script>
 <script src="src/mappings.js" type="text/javascript" charset="utf-8"></script>

--- a/src/base.js
+++ b/src/base.js
@@ -183,13 +183,12 @@ function copyAsCURL() {
 
 function handleCURLPaste(text) {
     _gaq.push(['_trackEvent', "curl", 'pasted']);
-    var curlInput = sense.curl.parseCURL(text);
-    if ($("#es_server").val()) curlInput.server = null; // do not override server
+    sense.curl.parseAll(text).forEach(function (curlInput, i, curls) {
+        if ($("#es_server").val()) curlInput.server = null; // do not override server
+        if (!curlInput.method) curlInput.method = "GET";
 
-    if (!curlInput.method) curlInput.method = "GET";
-
-    sense.editor.insert(sense.utils.textFromRequest(curlInput));
-
+        sense.editor.insert(sense.utils.textFromRequest(curlInput) + (curls.length - 1 === i ? '' : '\n\n'));
+    });
 }
 
 

--- a/src/curl.js
+++ b/src/curl.js
@@ -1,75 +1,167 @@
-(function () {
-   var global = window;
-   if (!global.sense)
-      global.sense = {};
+(function (global) {
+   var sense = global.sense = (global.sense || {});
 
-   function detectCURL(text) {
+   // multi-line, case insensitive, searching for a curl call somewhere at the begining of a line
+   var curlishRE = /^curl ([a-z\/][^ ]+ )?((-|("|')[a-z])|$)/mi;
+   var curlMethodFlagRE = /(?:^| )-X([A-Z]+)/;
+   var hasProtocolRE = /^(\w{2,}:)?\/\//;
+   var edgeWhiteSpaceRE = /(^\s+|\s+$)/g;
+
+   var curl = sense.curl = {};
+
+   curl.detectCURL = function (text) {
       // returns true if text matches a curl request
-      if (!text) return false;
-      return text.match(/^\s*?curl\s+(-X[A-Z]+)?\s*['"]?.*?['"]?(\s*$|\s+?-d\s*?['"])/);
+      return curlishRE.test(text);
+   };
 
-   }
+   /**
+    * Parse out all of the curl statements that can be found in the string ignoring everything else
+    *
+    * @param  {String} text - The text to parse
+    * @return {Object[]} - An array of objects from the parseFirst method
+    *
+    * @see sense.curl.parseFirst
+    */
+   curl.parseAll = function (text) {
+      var calls = [];
+      var match;
+      var chunk = text;
+      var call;
 
-   function parseCURL(text) {
-      var matches = text.match(/^\s*?curl\s+(?:-s\s+)?(-X\s*[A-Z]+)?\s*/);
-      var ret = {
-         method: "",
-         server: "",
-         endpoint: "",
-         data: ""
-      };
-      if (matches[1]) {
-         ret.method = matches[1].substring(2).trim(); // strip -X
-      }
-      text = text.substring(matches[0].length); // strip everything so far.
-      if (text.length == 0) return ret;
-      if (text[0] == '"') {
-         matches = text.match(/^"([^"]*)"/);
-      }
-      else if (text[0] == "'") {
-         matches = text.match(/^'([^']*)'/);
-      }
-      else {
-         matches = text.match(/^(\S*)/);
-      }
-
-      if (!matches) return ret;
-      var url = matches[1];
-
-      if (!url.match(/:\/\//)) url = "http://" + url; // inject http as curl does
-
-      var urlAnchor = document.createElement("a");
-      urlAnchor.href = url;
-
-      ret.server = (urlAnchor.protocol || "http") + "//" + urlAnchor.hostname;
-      if (urlAnchor.port && urlAnchor.port != 0) ret.server += ":" + urlAnchor.port;
-      ret.url = (urlAnchor.pathname || "") + (urlAnchor.search || "");
-
-      text = text.substring(matches[0].length);
-
-      // now search for -d
-      matches = text.match(/.*-d\s*?'/);
-      if (matches) {
-         ret.data = text.substring(matches[0].length).replace(/'\s*$/, '');
-      }
-      else {
-         matches = text.match(/.*-d\s*?"/);
-         if (matches) {
-            ret.data = text.substring(matches[0].length).replace(/"\s*$/, '');
-            ret.data = ret.data.replace(/\\(.)/gi, "$1");
+      for (var i = 0; i < 100 && chunk.length && (match = curlishRE.exec(chunk)); i++) {
+         chunk = chunk.substring(match.index);
+         call = curl.parseFirst(chunk);
+         if (call) {
+            chunk = chunk.substring(call.string.length);
+            calls.push(call);
+         } else {
+            chunk = chunk.substring(match[0].length);
          }
       }
 
-      if (ret.data) {
-         ret.data = ret.data.trim();
+      return calls;
+   };
+
+   /**
+    * Find the first curl statement in the string, parse it's args and return the
+    * useful args normalized
+    *
+    * @param  {String} text - The text to search
+    * @return {Object} - An object containing method, server, endpoint, data, and string keys describing
+    *                    the curl call.
+    */
+   curl.parseFirst = function (text) {
+      var args = splitIntoArgs(text);
+
+      // minimist will transport this list into a comprehensible object
+      // skip the "curl" token
+      var argv = minimist(args.slice(1), {
+         boolean: [
+            'I', 'head'
+         ],
+         alias: {
+            I: 'head',
+            X: 'method',
+            request: 'method',
+            d: 'data',
+            'data-ascii': 'data',
+            'data-binary': 'data'
+         }
+      });
+
+      // parse the servername and endpoint
+      var href = argv._.length ? resolveHref(argv._[0]) : {};
+
+      var ret = {
+         method: '',
+         server: href.server || '',
+         url: href.url || '',
+         data: (argv.data || '').replace(edgeWhiteSpaceRE, ''),
+         string: args.body || ''
+      };
+
+      if (argv.method) {
+         ret.method = argv.method;
+      } else if (!ret.method && argv.head) {
+         ret.method = 'HEAD';
       }
 
       return ret;
+   };
+
+   /**
+    * Split the string into tokens, repecting quoted strings (' or ") and finishing
+    * after the first unquoted newline.
+    *
+    * @param  {String} str - The string to split
+    * @return {Array} - An array of tokens, with an extra property "body" which contains
+    * the full text used to make the token list.
+    */
+   function splitIntoArgs(str) {
+      var args = [];
+      var inQuotes = false;
+      var part = '';
+      for (var i = 0; i < str.length; i++) {
+         prev = str[i - 1];
+         cur = str[i];
+         next = str[i + 1];
+
+         // toggle inQuotes
+         if (inQuotes) {
+            // only way out is matching inQuotes
+            if (cur === inQuotes && prev+cur !== "\\" + inQuotes) {
+               inQuotes = false;
+               continue;
+            }
+         }
+         else if (cur === ' ') {
+            // oooo! a word!
+            args.push(part);
+            part = '';
+            continue;
+         }
+         else if((cur === '"' && prev+cur !== '\\"') || (cur === "'" && prev+cur !== "\\'")) {
+            // we're on the record
+            inQuotes = inQuotes ? false : cur;
+            continue;
+         }
+         else if (cur+next === '\r\n' || cur === '\n') {
+            // it's the end of the non-quoted line sir
+            break;
+         }
+
+         part += cur;
+      }
+      if (part) {
+         args.push(part);
+      }
+
+      var tokens = [];
+      args.forEach(function (token) {
+         // split up -XMETHOD formatted tokens
+         if ((match = token.match(curlMethodFlagRE)) !== null) {
+            tokens.push('-X');
+            tokens.push(match[1]);
+         } else {
+            tokens.push(token);
+         }
+      });
+
+      tokens.body = str.substring(0, i);
+
+      return tokens;
    }
 
+   function resolveHref(href) {
+      if (!hasProtocolRE.test(href)) {
+         href = 'http://' + href;
+      }
+      var a = document.createElement('a');
+      a.href = href;
+      return {
+         server: a.protocol + '//' + a.host,
+         url: a.pathname + a.search
+      };
+   }
 
-   global.sense.curl = {};
-   global.sense.curl.parseCURL = parseCURL;
-   global.sense.curl.detectCURL = detectCURL;
-
-})();
+})(this);

--- a/src/minimist.js
+++ b/src/minimist.js
@@ -1,0 +1,197 @@
+/* jshint ignore:start */
+(function (root) {
+    root.minimist = function  (args, opts) {
+        if (!opts) opts = {};
+
+        var flags = { bools : {}, strings : {} };
+
+        [].concat(opts['boolean']).filter(Boolean).forEach(function (key) {
+            flags.bools[key] = true;
+        });
+
+        [].concat(opts.string).filter(Boolean).forEach(function (key) {
+            flags.strings[key] = true;
+        });
+
+        var aliases = {};
+        Object.keys(opts.alias || {}).forEach(function (key) {
+            aliases[key] = [].concat(opts.alias[key]);
+            aliases[key].forEach(function (x) {
+                aliases[x] = [key].concat(aliases[key].filter(function (y) {
+                    return x !== y;
+                }));
+            });
+        });
+
+        var defaults = opts['default'] || {};
+
+        var argv = { _ : [] };
+        Object.keys(flags.bools).forEach(function (key) {
+            setArg(key, defaults[key] === undefined ? false : defaults[key]);
+        });
+
+        var notFlags = [];
+
+        if (args.indexOf('--') !== -1) {
+            notFlags = args.slice(args.indexOf('--')+1);
+            args = args.slice(0, args.indexOf('--'));
+        }
+
+        function setArg (key, val) {
+            var value = !flags.strings[key] && isNumber(val)
+                ? Number(val) : val
+            ;
+            setKey(argv, key.split('.'), value);
+
+            (aliases[key] || []).forEach(function (x) {
+                setKey(argv, x.split('.'), value);
+            });
+        }
+
+        for (var i = 0; i < args.length; i++) {
+            var arg = args[i];
+
+            if (arg.match(/^--.+=/)) {
+                // Using [\s\S] instead of . because js doesn't support the
+                // 'dotall' regex modifier. See:
+                // http://stackoverflow.com/a/1068308/13216
+                var m = arg.match(/^--([^=]+)=([\s\S]*)$/);
+                setArg(m[1], m[2]);
+            }
+            else if (arg.match(/^--no-.+/)) {
+                var key = arg.match(/^--no-(.+)/)[1];
+                setArg(key, false);
+            }
+            else if (arg.match(/^--.+/)) {
+                var key = arg.match(/^--(.+)/)[1];
+                var next = args[i + 1];
+                if (next !== undefined && !next.match(/^-/)
+                && !flags.bools[key]
+                && (aliases[key] ? !flags.bools[aliases[key]] : true)) {
+                    setArg(key, next);
+                    i++;
+                }
+                else if (/^(true|false)$/.test(next)) {
+                    setArg(key, next === 'true');
+                    i++;
+                }
+                else {
+                    setArg(key, true);
+                }
+            }
+            else if (arg.match(/^-[^-]+/)) {
+                var letters = arg.slice(1,-1).split('');
+
+                var broken = false;
+                for (var j = 0; j < letters.length; j++) {
+                    var next = arg.slice(j+2);
+
+                    if (letters[j+1] && letters[j+1] === '=') {
+                        setArg(letters[j], arg.slice(j+3));
+                        broken = true;
+                        break;
+                    }
+
+                    if (next === '-') {
+                        setArg(letters[j], next)
+                        continue;
+                    }
+
+                    if (/[A-Za-z]/.test(letters[j])
+                    && /-?\d+(\.\d*)?(e-?\d+)?$/.test(next)) {
+                        setArg(letters[j], next);
+                        broken = true;
+                        break;
+                    }
+
+                    if (letters[j+1] && letters[j+1].match(/\W/)) {
+                        setArg(letters[j], arg.slice(j+2));
+                        broken = true;
+                        break;
+                    }
+                    else {
+                        setArg(letters[j], true);
+                    }
+                }
+
+                var key = arg.slice(-1)[0];
+                if (!broken && key !== '-') {
+                    if (args[i+1] && !/^(-|--)[^-]/.test(args[i+1])
+                    && !flags.bools[key]
+                    && (aliases[key] ? !flags.bools[aliases[key]] : true)) {
+                        setArg(key, args[i+1]);
+                        i++;
+                    }
+                    else if (args[i+1] && /true|false/.test(args[i+1])) {
+                        setArg(key, args[i+1] === 'true');
+                        i++;
+                    }
+                    else {
+                        setArg(key, true);
+                    }
+                }
+            }
+            else {
+                argv._.push(
+                    flags.strings['_'] || !isNumber(arg) ? arg : Number(arg)
+                );
+            }
+        }
+
+        Object.keys(defaults).forEach(function (key) {
+            if (!hasKey(argv, key.split('.'))) {
+                setKey(argv, key.split('.'), defaults[key]);
+
+                (aliases[key] || []).forEach(function (x) {
+                    setKey(argv, x.split('.'), defaults[key]);
+                });
+            }
+        });
+
+        notFlags.forEach(function(key) {
+            argv._.push(key);
+        });
+
+        return argv;
+    };
+
+    function hasKey (obj, keys) {
+        var o = obj;
+        keys.slice(0,-1).forEach(function (key) {
+            o = (o[key] || {});
+        });
+
+        var key = keys[keys.length - 1];
+        return key in o;
+    }
+
+    function setKey (obj, keys, value) {
+        var o = obj;
+        keys.slice(0,-1).forEach(function (key) {
+            if (o[key] === undefined) o[key] = {};
+            o = o[key];
+        });
+
+        var key = keys[keys.length - 1];
+        if (o[key] === undefined || typeof o[key] === 'boolean') {
+            o[key] = value;
+        }
+        else if (Array.isArray(o[key])) {
+            o[key].push(value);
+        }
+        else {
+            o[key] = [ o[key], value ];
+        }
+    }
+
+    function isNumber (x) {
+        if (typeof x === 'number') return true;
+        if (/^0x[0-9a-f]+$/i.test(x)) return true;
+        return /^[-+]?(?:\d+(?:\.\d*)?|\.\d+)(e[-+]?\d+)?$/.test(x);
+    }
+
+    function longest (xs) {
+        return Math.max.apply(null, xs.map(function (x) { return x.length }));
+    }
+
+})(this);

--- a/tests/index.html
+++ b/tests/index.html
@@ -21,6 +21,7 @@
 <script src="../lib/jqueryui/jquery-ui-1.9.2.custom.min.js" type="text/javascript"></script>
 <script src="../lib/src-noconflict/ace.js" type="text/javascript" charset="utf-8"></script>
 <script src="../src/utils.js" type="text/javascript" charset="utf-8"></script>
+<script src="../src/minimist.js" type="text/javascript" charset="utf-8"></script>
 <script src="../src/curl.js" type="text/javascript" charset="utf-8"></script>
 <script src="../src/kb.js" type="text/javascript" charset="utf-8"></script>
 <script src="../src/autocomplete.js" type="text/javascript" charset="utf-8"></script>

--- a/tests/src/curl_tests.js
+++ b/tests/src/curl_tests.js
@@ -16,147 +16,203 @@ module("CURL", {
 var notCURLS = [
    'sldhfsljfhs',
    's;kdjfsldkfj curl -XDELETE ""',
-   '{ "hello": 1 }'
+   '{ "hello": 1 }',
+   'curl up like a ball',
+   'curlly hair'
 ];
+
+
+// stringify an object, with random indentation (or none) and quotes.
+function stringify(obj) {
+   var q = Math.random() * 100 > 50 ? "'" : '"';
+   var qRE = new RegExp(q, 'g');
+   var indent = Array(Math.floor(Math.random() * 6)).join(' ') || undefined;
+   return q + JSON.stringify(obj, null, indent).replace(qRE, '\\' + q) + q;
+}
+
+function giveLeadingNewLine(quotedStr) {
+   return quotedStr.charAt(0) + '\n' + quotedStr.substring(1);
+}
+
+function unwrapQuotes(str) {
+   if (str[0] === '"' || str[0] === "'") {
+      var quote = str[0];
+      str = str.substring(1, str.length-1).replace(new RegExp('\\'+quote, 'g'), quote);
+   }
+   return str;
+}
+
+var tweetsJSON = [
+   {
+      user: 'kimchy',
+      post_date: '2009-11-15T14:12:12',
+      message: 'trying out Elastic Search'
+   },
+   {
+      message: 'elasticsearch now has versioning support, double cool!'
+   }
+].map(stringify);
+
+var mappingJSON = stringify({
+   mappings: {
+   }
+});
+
+var queryJSON = stringify({
+   query: {
+   }
+});
 
 var CURLS = [
    {
-      "curl": "curl -XPUT 'http://localhost:9200/twitter/tweet/1' -d '{ \
-            \"user\" : \"kimchy\", \
-         \"post_date\" : \"2009-11-15T14:12:12\",\
-         \"message\" : \"trying out Elastic Search\"\
-         }'",
-      "ret": {
-         "server": "http://localhost:9200",
-         "method": "PUT",
-         "url": "/twitter/tweet/1",
-         "data": "{ \
-            \"user\" : \"kimchy\", \
-         \"post_date\" : \"2009-11-15T14:12:12\",\
-         \"message\" : \"trying out Elastic Search\"\
-         }"
-      }
+      curl: "curl -XPUT 'http://localhost:9200/twitter/tweet/1' -d " + tweetsJSON[0],
+      ret: [
+         {
+            server: "http://localhost:9200",
+            method: "PUT",
+            url: "/twitter/tweet/1",
+            data: tweetsJSON[0]
+         }
+      ]
    },
    {
-      "curl": "curl -XGET \"localhost/twitter/tweet/1?version=2\" -d '{ \
-    \"message\" : \"elasticsearch now has versioning support, double cool!\"\
-     }'",
-      "ret": {
-         "server": "http://localhost",
-         "method": "GET",
-         "url": "/twitter/tweet/1?version=2",
-         "data": "{ \
-    \"message\" : \"elasticsearch now has versioning support, double cool!\"\
-     }"
-      }
+      curl: "curl -XGET \"localhost/twitter/tweet/1?version=2\" -d=" + tweetsJSON[1],
+      ret: [
+         {
+            server: "http://localhost",
+            method: "GET",
+            url: "/twitter/tweet/1?version=2",
+            data: tweetsJSON[1]
+         }
+      ]
    },
    {
-      "curl": "curl -XPOST https://localhost/twitter/tweet/1?version=2 -d '{ \n\
-    \"message\" : \"elasticsearch now has versioning support, double cool!\"\n\
-     }'",
-      "ret": {
-         "server": "https://localhost",
-         "method": "POST",
-         "url": "/twitter/tweet/1?version=2",
-         "data": "{ \n\
-    \"message\" : \"elasticsearch now has versioning support, double cool!\"\n\
-     }"
-      }
+      curl: "curl -XPOST https://localhost/twitter/tweet/1?version=2 -d " + tweetsJSON[1],
+      ret: [
+         {
+            server: "https://localhost",
+            method: "POST",
+            url: "/twitter/tweet/1?version=2",
+            data: tweetsJSON[1]
+         }
+      ]
    },
    {
-      "curl": "curl -XPOST https://localhost/twitter",
-      "ret": {
-         "server": "https://localhost",
-         "method": "POST",
-         "url": "/twitter",
-         "data": ""
-      }
+      curl: "curl -XPOST https://localhost/twitter",
+      ret: [
+         {
+            server: "https://localhost",
+            method: "POST",
+            url: "/twitter",
+            data: ""
+         }
+      ]
    },
    {
-      "curl": "curl -X POST https://localhost/twitter/",
-      "ret": {
-         "server": "https://localhost",
-         "method": "POST",
-         "url": "/twitter/",
-         "data": ""
-      }
+      curl: "curl -X POST https://localhost/twitter/",
+      ret: [
+         {
+            server: "https://localhost",
+            method: "POST",
+            url: "/twitter/",
+            data: ""
+         }
+      ]
    },
    {
-      "curl": "curl -s -XPOST localhost:9200/missing-test -d'\n\
-   { \n\
-      \"mappings\": {\n\
-      }\n\
-   }'",
-      "ret": {
-         "server": "http://localhost:9200",
-         "method": "POST",
-         "url": "/missing-test",
-         "data": "{ \n\
-      \"mappings\": {\n\
-      }\n\
-   }"
-      }
+      curl: "curl -s -XPOST localhost:9200/missing-test -d" + mappingJSON,
+      ret: [
+         {
+            server: "http://localhost:9200",
+            method: "POST",
+            url: "/missing-test",
+            data: mappingJSON
+         }
+      ]
    },
    {
-      "curl": "curl 'localhost:9200/missing-test/doc/_search?pretty' -d'\n\
-   {\n\
-      \"query\": {\n\
-      },\n\
-   }'",
-      "ret": {
-         "server": "http://localhost:9200",
-         "method": "",
-         "url": "/missing-test/doc/_search?pretty",
-         "data": "{\n\
-      \"query\": {\n\
-      },\n\
-   }"
-      }
+      curl: "curl 'localhost:9200/missing-test/doc/_search?pretty' -d" + giveLeadingNewLine(queryJSON),
+      ret: [
+         {
+            server: "http://localhost:9200",
+            method: "",
+            url: "/missing-test/doc/_search?pretty",
+            data: queryJSON
+         }
+      ]
    },
    {
-      "curl": 'curl localhost:9200/ -d"\n\
-   {\n\
-      \\"query\\": {\n\
-      },\n\
-   }"',
-      "ret": {
-         "server": "http://localhost:9200",
-         "method": "",
-         "url": "/",
-         "data": "{\n\
-      \"query\": {\n\
-      },\n\
-   }"
-      }
+      // complex example copied from chrome's network inspector
+      curl: 'curl \'http://demo.kibana.org/logstash-2013.10.25/_search\' -H \'Pragma: no-cache\' -H \'Origin: http://demo.kibana.org\' -H \'Accept-Encoding: gzip,deflate,sdch\' -H \'Host: demo.kibana.org\' -H \'Accept-Language: en-US,en;q=0.8\' -H \'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.101 Safari/537.36\' -H \'Content-Type: application/json;charset=UTF-8\' -H \'Accept: application/json, text/plain, */*\' -H \'Cache-Control: no-cache\' -H \'Referer: http://demo.kibana.org/\' -H \'Connection: keep-alive\' --data-binary \'{"facets":{"0":{"date_histogram":{"field":"@timestamp","interval":"10m"},"facet_filter":{"fquery":{"query":{"filtered":{"query":{"query_string":{"query":"html"}},"filter":{"bool":{"must":[{"match_all":{}},{"range":{"@timestamp":{"from":1382651717617,"to":"now"}}},{"bool":{"must":[{"match_all":{}}]}}]}}}}}}},"1":{"date_histogram":{"field":"@timestamp","interval":"10m"},"facet_filter":{"fquery":{"query":{"filtered":{"query":{"query_string":{"query":"php"}},"filter":{"bool":{"must":[{"match_all":{}},{"range":{"@timestamp":{"from":1382651717619,"to":"now"}}},{"bool":{"must":[{"match_all":{}}]}}]}}}}}}},"2":{"date_histogram":{"field":"@timestamp","interval":"10m"},"facet_filter":{"fquery":{"query":{"filtered":{"query":{"query_string":{"query":"css"}},"filter":{"bool":{"must":[{"match_all":{}},{"range":{"@timestamp":{"from":1382651717619,"to":"now"}}},{"bool":{"must":[{"match_all":{}}]}}]}}}}}}},"3":{"date_histogram":{"field":"@timestamp","interval":"10m"},"facet_filter":{"fquery":{"query":{"filtered":{"query":{"query_string":{"query":"png"}},"filter":{"bool":{"must":[{"match_all":{}},{"range":{"@timestamp":{"from":1382651717619,"to":"now"}}},{"bool":{"must":[{"match_all":{}}]}}]}}}}}}},"4":{"date_histogram":{"field":"@timestamp","interval":"10m"},"facet_filter":{"fquery":{"query":{"filtered":{"query":{"query_string":{"query":"gif"}},"filter":{"bool":{"must":[{"match_all":{}},{"range":{"@timestamp":{"from":1382651717619,"to":"now"}}},{"bool":{"must":[{"match_all":{}}]}}]}}}}}}}},"size":0}\' --compressed\'',
+      ret: [
+         {
+            server: 'http://demo.kibana.org',
+            url: '/logstash-2013.10.25/_search',
+            method: '',
+            data: '{"facets":{"0":{"date_histogram":{"field":"@timestamp","interval":"10m"},"facet_filter":{"fquery":{"query":{"filtered":{"query":{"query_string":{"query":"html"}},"filter":{"bool":{"must":[{"match_all":{}},{"range":{"@timestamp":{"from":1382651717617,"to":"now"}}},{"bool":{"must":[{"match_all":{}}]}}]}}}}}}},"1":{"date_histogram":{"field":"@timestamp","interval":"10m"},"facet_filter":{"fquery":{"query":{"filtered":{"query":{"query_string":{"query":"php"}},"filter":{"bool":{"must":[{"match_all":{}},{"range":{"@timestamp":{"from":1382651717619,"to":"now"}}},{"bool":{"must":[{"match_all":{}}]}}]}}}}}}},"2":{"date_histogram":{"field":"@timestamp","interval":"10m"},"facet_filter":{"fquery":{"query":{"filtered":{"query":{"query_string":{"query":"css"}},"filter":{"bool":{"must":[{"match_all":{}},{"range":{"@timestamp":{"from":1382651717619,"to":"now"}}},{"bool":{"must":[{"match_all":{}}]}}]}}}}}}},"3":{"date_histogram":{"field":"@timestamp","interval":"10m"},"facet_filter":{"fquery":{"query":{"filtered":{"query":{"query_string":{"query":"png"}},"filter":{"bool":{"must":[{"match_all":{}},{"range":{"@timestamp":{"from":1382651717619,"to":"now"}}},{"bool":{"must":[{"match_all":{}}]}}]}}}}}}},"4":{"date_histogram":{"field":"@timestamp","interval":"10m"},"facet_filter":{"fquery":{"query":{"filtered":{"query":{"query_string":{"query":"gif"}},"filter":{"bool":{"must":[{"match_all":{}},{"range":{"@timestamp":{"from":1382651717619,"to":"now"}}},{"bool":{"must":[{"match_all":{}}]}}]}}}}}}}},"size":0}'
+         }
+      ]
+   },
+   {
+      curl: [
+         "# shell comment",
+         "// js comment",
+         "git status",
+         "curl 'localhost:9200/missing-test/doc/_search?pretty' -d=" + queryJSON,
+         "curl localhost:9200 -d=" + queryJSON,
+         "curl //localhost:9200 -d=" + queryJSON,
+         "curl -XPOST https://localhost/twitter/tweet/1?version=2 -d " + tweetsJSON[1]
+      ].join('\n'),
+      ret: [
+         {
+            server: "http://localhost:9200",
+            method: "",
+            url: "/missing-test/doc/_search?pretty",
+            data: queryJSON
+         },
+         {
+            server: "http://localhost:9200",
+            method: "",
+            url: "/",
+            data: queryJSON
+         },
+         {
+            server: "http://localhost:9200",
+            method: "",
+            url: "/",
+            data: queryJSON
+         },
+         {
+            server: "https://localhost",
+            method: "POST",
+            url: "/twitter/tweet/1?version=2",
+            data: tweetsJSON[1]
+         }
+      ]
    }
 ];
 
-
-function compareCURL(result, expected) {
-   deepEqual(result.server, expected.server);
-   deepEqual(result.method, expected.method);
-   deepEqual(result.url, expected.url);
-   deepEqual(result.data, expected.data);
+function compareCURL(results, expecteds) {
+   ok(results.length === expecteds.length, "expected " + expecteds.length + " results, got " + results.length);
+   expecteds.forEach(function (expected, i) {
+      var result = results[i] || {};
+      deepEqual(result.server, expected.server);
+      deepEqual(result.method, expected.method);
+      deepEqual(result.url, expected.url);
+      deepEqual(result.data, unwrapQuotes(expected.data));
+   });
 }
 
-for (var i = 0; i < notCURLS.length; i++)
+notCURLS.forEach(function (notCURL, i) {
+   test("cURL Detection - broken strings " + i, function () {
+      ok(!global.sense.curl.detectCURL(notCURL), "marked as curl while it wasn't:" + notCURL);
+   });
+});
 
-   test("cURL Detection - broken strings " + i, function (c) {
-      return function () {
-         ok(!global.sense.curl.detectCURL(notCURLS[c]), "marked as curl while it wasn't:" + notCURLS[c]);
-      }
-   }(i)
-   );
-
-for (var i = 0; i < CURLS.length; i++)
-
-
-   test("cURL Detection - correct strings " + i, function (c) {
-      return function () {
-         ok(global.sense.curl.detectCURL(CURLS[c].curl), "marked as not curl while it was:" + CURLS[c].curl);
-         var r = global.sense.curl.parseCURL(CURLS[c].curl);
-         compareCURL(r, CURLS[c].ret);
-      }
-   }(i)
-   );
-
+CURLS.forEach(function (CURL, i) {
+   test("cURL Detection - correct strings " + i, function () {
+      ok(global.sense.curl.detectCURL(CURL.curl), "marked as not curl while it was:" + CURL.curl);
+      var r = global.sense.curl.parseAll(CURL.curl);
+      compareCURL(r, CURL.ret);
+   });
+});


### PR DESCRIPTION
Curl commands are currently recognized using a RegExp that searches for:
- line starting with `curl` (with the space)
  - may be followed by a single unquoted word
  - must be followed by a hyphen or quoted string

This mean that the following strings would pass:
- `curl "*"`
- `curl -XPOST ...`
- `curl localhost -XPOST`

The only example I can think of that won't be recognized is `curl locahost` (without any args/flags). I think that allowing this to pass would be too liberal, but please let me know if you can think of a better way to find these statements.

I've added tests for this as well, and you can use [this gist](https://gist.github.com/spenceralger/f6df9a45bc5802b4a540) if you want to see it _in action_
