### PR TITLE
Make request over https if loaded that way

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -506,7 +506,7 @@ function init() {
 
     if (document.location.pathname && document.location.pathname.indexOf("_plugin") == 1) {
         // running as an ES plugin. Always assume we are using that elasticsearch
-        resetToValues(document.location.host);
+        resetToValues(document.location.protocol+"//"+document.location.host);
     }
 
     sense.editor.focus();


### PR DESCRIPTION
I get an error when using an apache ssl proxy:
    The page at 'https://logsearch/_plugin/sense/' was loaded over HTTPS, but displayed insecure content from 'http://logsearch/_search': this content should also be loaded over HTTPS.

This is resolved by adding https:// to the front of the server and saves users having to manually modify the provided default value
